### PR TITLE
Fix typo, project.basedir instead of project-basedir

### DIFF
--- a/src/main/java/com/worldline/maven/plugin/externalTasksRunner/SubTaskInitializerMojo.java
+++ b/src/main/java/com/worldline/maven/plugin/externalTasksRunner/SubTaskInitializerMojo.java
@@ -36,7 +36,7 @@ public class SubTaskInitializerMojo extends AbstractMojo {
      * @required
      * @readonly
      */
-	@Parameter(property = "external-tasks-maven.basedir", defaultValue = "${project-basedir}")
+	@Parameter(property = "external-tasks-maven.basedir", defaultValue = "${project.basedir}")
     protected File basedir;
 
 

--- a/src/main/java/com/worldline/maven/plugin/externalTasksRunner/SubTaskRunnerMojo.java
+++ b/src/main/java/com/worldline/maven/plugin/externalTasksRunner/SubTaskRunnerMojo.java
@@ -42,7 +42,7 @@ public class SubTaskRunnerMojo extends AbstractMojo {
      * @required
      * @readonly
      */
-	@Parameter(property = "external-tasks-maven.basedir", defaultValue = "${project-basedir}")
+	@Parameter(property = "external-tasks-maven.basedir", defaultValue = "${project.basedir}")
 	protected File basedir;
 
     @Parameter(property = "skipTests", defaultValue = "false")


### PR DESCRIPTION
Hi, 

We had a problem with basedir when installing a multi module parent (parent's basedir instead of child's one). Passing the good value (${project.basedir}) fixed the problem, i think parent-basedir doesn't exist.

(thx to Florent !)
